### PR TITLE
Pass sysroot and compile flags to cpptools extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 out
 node_modules
+dist/
+.vscode/
 .vscode-test/
 *.vsix

--- a/src/cmake/client.ts
+++ b/src/cmake/client.ts
@@ -291,6 +291,7 @@ export class CMakeClient extends CMake {
                                     compileFlags: sFG.compileFlags,
                                     compilerPath: "",
                                     defines: sFG.defines || [],
+                                    sysroot: st.sysroot || "",
                                     includePaths: (sFG.includePath || []).map((sI) => {
                                         return {
                                             path: sI.path

--- a/src/cmake/commandClient.ts
+++ b/src/cmake/commandClient.ts
@@ -267,6 +267,7 @@ class CommandClient extends CMake {
               compilerPath: "",
               defines: [],
               includePaths: [],
+              sysroot: cg.sysroot ? cg.sysroot.path || "" : "",
               language: cg.language,
               sources: cg.sourceIndexes.map((index) => targetFile.sources[index].path)
             };

--- a/src/cmake/model.ts
+++ b/src/cmake/model.ts
@@ -7,6 +7,7 @@ interface Target {
     language: string;
     compilerPath: string;
     compileFlags: string;
+    sysroot: string;
     sources: string[];
     defines: string[];
     includePaths: {

--- a/src/cpptools/configurationProvider.ts
+++ b/src/cpptools/configurationProvider.ts
@@ -281,9 +281,17 @@ class ConfigurationProvider implements CustomConfigurationProvider {
         }
       }
 
+      let cpptoolsCompilerPath = compilerPath;
+      if (fg.compileFlags) {
+        cpptoolsCompilerPath += fg.compileFlags;
+      }
+      if (fg.sysroot) {
+        cpptoolsCompilerPath += ` "--sysroot=${fg.sysroot}"`;
+      }
+
       // Set config
       let configuration: SourceFileConfiguration = {
-        compilerPath,
+        compilerPath: cpptoolsCompilerPath,
         includePath,
         defines,
         intelliSenseMode,


### PR DESCRIPTION
This pull request changes the `compilerPath` parameter that is passed to the vscode-cpptools extension API.

When cross compiling there are often applied hardware related compiler flags that alter the resulting system defines. Also a sysroot option may changes the location of the system include paths.
By appending these parameters to the `compilerPath` parameter, the vscode-cpptools extension is able to browse the system defines and include paths from the used compiler.

Tested with gcc arm-linux-gnueabihf toolchain.
Used compile flags: `-march=armv7-a -mthumb -mfpu=neon -mfloat-abi=hard -mcpu=cortex-a9`